### PR TITLE
Fix filenames in source map output

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,8 @@ function jstransformify(filename, opts) {
         });
 
         var map = sourceMap.fromJSON(r.sourceMap);
+        map.sourcemap.file = filename;
+        map.sourcemap.sources = [filename];
         map.sourcemap.sourcesContent = [src];
 
         this.queue(r.code + '\n' + map.toComment());


### PR DESCRIPTION
The source map object from jstransform has the wrong file name, which breaks the source maps. This change forces the file names in the source map to match the file name from browserify.
