### PR TITLE
Use the "simple" jstransform API

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,10 @@
 'use strict';
 
-var path        = require('path');
-var sourceMap   = require('convert-source-map');
 var jstransform = require('jstransform/simple');
 var through     = require('through');
 
-var cache = {};
-
 function jstransformify(filename, opts) {
   var src = '';
-  var visitorList = [];
 
   if (/\.json$/.test(filename)) {
     return through();
@@ -37,10 +32,6 @@ function getTransformOptions(options, filename) {
     out[k] = options[k];
   }
   return out;
-}
-
-function isString(o) {
-  return Object.prototype.toString.call(o) === '[object String]';
 }
 
 module.exports = jstransformify;

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   },
   "homepage": "https://github.com/andreypopp/jstransformify",
   "dependencies": {
-    "through": "^2.3.6",
-    "jstransform": "^8.0.0",
+    "convert-source-map": "^0.4.1",
+    "jstransform": "^11.0.1",
     "resolve": "^1.0.0",
-    "convert-source-map": "^0.4.1"
+    "through": "^2.3.6"
   },
   "devDependencies": {
     "mocha": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/andreypopp/jstransformify",
   "dependencies": {
-    "convert-source-map": "^0.4.1",
     "jstransform": "^11.0.1",
     "resolve": "^1.0.0",
     "through": "^2.3.6"

--- a/specs.js
+++ b/specs.js
@@ -7,7 +7,7 @@ describe('jstransformify', function() {
 
   it('works', function(done) {
     browserify('./fixture')
-      .transform({visitors: 'jstransform/visitors/es6-class-visitors'}, jstransformify)
+      .transform({es6: true}, jstransformify)
       .bundle(function(err, code) {
         if (err) return done(err);
         assert.ok(code);


### PR DESCRIPTION
Facebook is in the process of [deprecating react-tools in favor of jstransform](https://github.com/facebook/flow/issues/267#issuecomment-97236685). In order to use a new feature of FlowType, I needed to update the version of jstransform used by jstransformify.

This PR obviously breaks backwards compatibility, but I wanted to send it out for comments anyway. The "simple" interface is much easier to use than the visitors list interface, especially if you're coming from reactify. Given the deprecation of react-tools, that's likely to be happening a lot in the near future.

If you're OK with this, I'd be happy to take a stab at making a backwards-compatible version. In the meantime, I'll just use my fork.

cc @zpao @jeffmo

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/andreypopp/jstransformify/6)

<!-- Reviewable:end -->
